### PR TITLE
feat(chat): implement position-based channel visibility (UC-002)

### DIFF
--- a/docs/Core/positions-reference/Position.cs
+++ b/docs/Core/positions-reference/Position.cs
@@ -1,0 +1,34 @@
+﻿using Cobra.Domain.Interfaces;
+
+namespace Cobra.Domain.Entities;
+/// <summary>
+/// 
+/// </summary>
+public class Position : ISoftDeletableEntity, IUserModifiableEntity, IOrganizationDataEntity, ITranslatableEntity<PositionTranslation>
+{
+    public DateTime Created { get; set; }
+
+    public User CreatedBy { get; set; } = default!;
+
+    public Guid CreatedById { get; set; }
+
+    public required Guid Id { get; set; }
+
+    public bool IsActive { get; set; } = true;
+
+    public DateTime Modified { get; set; }
+
+    public User ModifiedBy { get; set; } = default!;
+
+    public Guid ModifiedById { get; set; }
+
+    public Organization Organization { get; set; } = default!;
+
+    public required Guid OrganizationId { get; set; }
+
+    public Language SourceLanguage { get; set; } = default!;
+
+    public required Guid SourceLanguageId { get; set; }
+
+    public ICollection<PositionTranslation> Translations { get; set; } = default!;
+}

--- a/docs/Core/positions-reference/PositionDto.cs
+++ b/docs/Core/positions-reference/PositionDto.cs
@@ -1,0 +1,7 @@
+﻿namespace Cobra.Application.Common.Models;
+
+public class PositionDto
+{
+    public required string Name { get; set; }
+    public string? Description { get; set; }
+}

--- a/docs/Core/positions-reference/PositionService.cs
+++ b/docs/Core/positions-reference/PositionService.cs
@@ -1,0 +1,153 @@
+﻿using AutoMapper;
+using Azure.Core.GeoJson;
+using Cobra.Application.Common.Exceptions;
+using Cobra.Application.Common.Interfaces;
+using Cobra.Application.Common.Models;
+using Cobra.Application.Common.Validators;
+using Cobra.Domain.Common;
+using Cobra.Domain.Entities;
+using Cobra.Domain.Enums;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace Cobra.Application.Services;
+
+
+
+public class PositionService : BaseService, IPositionService
+{
+    readonly IMapper _mapper;
+
+
+    public PositionService(IOptionsSnapshot<CobraConfigurationSettings> cobraSettingsSnapshot, IUserContextService userContextService, IFilteredDbContextService filteredContextService, IMapper mapper)
+        : base(cobraSettingsSnapshot, userContextService, filteredContextService)
+    {
+        _mapper = mapper;
+    }
+
+
+    public IQueryable<ViewPositionDto> GetPositionDtoQueryable()
+    {
+        var withTranslations = _dbContext.Positions.Select(pos => new
+        {
+            DesiredTranslation = pos.Translations.SingleOrDefault(ett => ett.LanguageId == CurrentUserContext.LanguageId),
+            SourceTranslation = pos.Translations.SingleOrDefault(ett => ett.LanguageId == pos.SourceLanguageId),
+            Id = pos.Id,
+            OrganizationId = pos.OrganizationId,
+        });
+
+        return withTranslations.Select(pos => new ViewPositionDto
+        {
+            Name = pos.DesiredTranslation != null && pos.DesiredTranslation.Name != null ? pos.DesiredTranslation.Name : pos.SourceTranslation!.Name,
+            Id = pos.Id
+        }).OrderBy(p => p.Name);
+    }
+
+    public async Task<List<ViewPositionDto>> GetPositions()
+    {
+        return await GetPositionDtoQueryable().ToListAsync();
+    }
+
+
+    public async Task<ViewPositionDto> GetPosition(Guid id)
+    {
+        var dto = await GetPositionDtoQueryable().SingleOrDefaultAsync(p => p.Id == id);
+        if (dto == null)
+        {
+            throw new NotFoundException();
+        }
+        return dto;
+    }
+
+    public async Task<List<ViewPositionDto>> GetPositions(List<Guid> ids)
+    {
+        return await GetPositionDtoQueryable().Where(p => ids.Contains(p.Id)).ToListAsync();
+    }
+
+    public async Task<Guid> CreatePosition(PositionDto newPosition)
+    {
+        PositionValidator validator = new PositionValidator();
+        validator.ValidateAndThrow(newPosition);
+
+        Guid positionToCreateGuid = Guid.NewGuid();
+
+        Position positionToCreate = new()
+        {
+            Id = positionToCreateGuid,
+            IsActive = true,
+            OrganizationId = CurrentUserContext.OrganizationId!.Value,
+            SourceLanguageId = CurrentUserContext.LanguageId
+        };
+
+        _dbContext.Positions.Add(positionToCreate);
+        _dbContext.Add(new PositionTranslation
+        {
+            LanguageId = CurrentUserContext.LanguageId,
+            Name = newPosition.Name,
+            Description = newPosition.Description,
+            PositionId = positionToCreateGuid,
+        });
+
+        await _dbContext.SaveChangesAsync(Domain.Entities.Action.PositionCreated, positionToCreateGuid, CurrentUserContext.LanguageId, newPosition.Name);
+
+        return positionToCreateGuid;
+    }
+
+    private async Task<Position> EnsurePosition(Guid id)
+    {
+        var foundPosition = await _dbContext.Positions.SingleOrDefaultAsync(po => po.Id == id);
+        if (foundPosition == null)
+        {
+            throw new NotFoundException();
+        }
+        return foundPosition;
+    }
+
+    public async Task EditPosition(Guid id, PositionDto positionDto)
+    {
+        var position = await EnsurePosition(id);
+
+        var originalName = position.Translations.FirstOrDefault(ect => ect.LanguageId == CurrentUserContext.LanguageId)?.Name ?? string.Empty;
+
+        var existingLanguageTranslation = position.Translations.FirstOrDefault(ect => ect.LanguageId == CurrentUserContext.LanguageId);
+        if (existingLanguageTranslation != null)
+        {
+            existingLanguageTranslation.Name = positionDto.Name;
+            existingLanguageTranslation.Description = positionDto.Description;
+        }
+        else
+        {
+            _dbContext.Add(new PositionTranslation
+            {
+                PositionId = position.Id,
+                Name = positionDto.Name,
+                Description = positionDto.Description,
+                LanguageId = CurrentUserContext.LanguageId
+            });
+        }
+
+        EnsurePrimaryEntityUpdate(position);
+        await _dbContext.SaveChangesAsync(Domain.Entities.Action.PositionEdited, id, position.SourceLanguageId, positionDto.Name);
+    }
+
+    public async Task DeletePosition(Guid id)
+    {
+        var position = await EnsurePosition(id);
+
+        position.IsActive = false; // Soft delete
+
+        PositionTranslation? translation;
+        if (position.Translations.Any(wt => wt.LanguageId == CurrentUserContext.LanguageId))
+        {
+            translation = position.Translations.FirstOrDefault(wt => wt.LanguageId == CurrentUserContext.LanguageId);
+        }
+        else
+        {
+            translation = position.Translations.FirstOrDefault(wt => wt.LanguageId == position.SourceLanguageId);
+        }
+
+        await _dbContext.SaveChangesAsync(Domain.Entities.Action.PositionDeleted, id, position.SourceLanguageId, translation?.Name);
+
+    }
+}

--- a/docs/Core/positions-reference/PositionTranslation.cs
+++ b/docs/Core/positions-reference/PositionTranslation.cs
@@ -1,0 +1,21 @@
+﻿using Cobra.Domain.Interfaces;
+
+namespace Cobra.Domain.Entities;
+
+/// <summary>
+/// 
+/// </summary>
+public class PositionTranslation : ITranslationEntity
+{
+    public string? Description { get; set; }
+
+    public Position Position { get; set; } = default!;
+
+    public required Guid PositionId { get; set; }
+
+    public Language Language { get; set; } = default!;
+
+    public required Guid LanguageId { get; set; }
+
+    public required string Name { get; set; }
+}

--- a/docs/ExternalChatIntegration/USER-STORIES.md
+++ b/docs/ExternalChatIntegration/USER-STORIES.md
@@ -92,21 +92,27 @@
 
 **Title:** Create additional internal channels for an event
 
-**As a** user with Manage permissions  
-**I want** to create additional internal channels  
+**As a** user with Manage permissions
+**I want** to create additional internal channels
 **So that** I can organize conversations by topic, section, or team
 
 **Acceptance Criteria:**
-- [ ] User with Manage permissions can create new internal channels
-- [ ] Channel name is required and must be unique within the event
-- [ ] Optional channel description field
-- [ ] New channel appears in sidebar accordion and full-page tabs
-- [ ] New internal channels never bridge to external platforms
-- [ ] Channel creation is logged for verification
+- [x] User with Manage permissions can create new internal channels
+- [x] Channel name is required and must be unique within the event
+- [x] Optional channel description field
+- [x] New channel appears in sidebar accordion and full-page tabs
+- [x] New internal channels never bridge to external platforms
+- [x] Channel creation is logged for verification
+- [x] Optional: Restrict channel visibility to a specific ICS position
+  - Position selector dropdown with positions from database
+  - When a position is selected, channel type becomes Position
+  - Only users assigned to that position can see the channel
+  - Users with Manage role can see all channels regardless of position
+  - Helper text explains visibility restriction when position is selected
 
 **Dependencies:** UC-001
 
-**Notes:** Examples: "Operations", "Logistics", "Safety", "Structure Fire - 123 Main St"
+**Notes:** Examples: "Operations", "Logistics", "Safety", "Structure Fire - 123 Main St". Position-restricted channels are useful for sensitive coordination (e.g., "Safety Officer Coordination" visible only to Safety Officers).
 
 ---
 
@@ -848,13 +854,14 @@ CREATE INDEX IX_UserChannelReadState_UserId ON UserChannelReadState(UserId);
 
 ## Implementation Status
 
-*Last Updated: 2025-12-02*
+*Last Updated: 2025-12-03*
 
 ### Completed
 
 | Story | Title | Notes |
 |-------|-------|-------|
 | UC-001 | Auto-Create Default Channels | Complete: Backend auto-creates channels on event creation. Frontend ChannelList component displays channels in sidebar accordion. Announcements channel shows read-only message. Role-based write permission pending. |
+| UC-004 | Manually Create Internal Channel | Complete: Create channel dialog with optional position restriction. Position selector using Autocomplete with database-defined positions. Position channels visible only to assigned users; Manage role sees all. |
 | UC-005 | Create GroupMe Channel | Create new GroupMe group for event. Includes duplicate prevention and reconnect support. |
 | UC-007 | Disconnect External Channel | Deactivate channel (soft delete). Reconnecting reactivates the same GroupMe group. |
 | UC-009 | Receive External Messages | Webhook receives GroupMe messages and displays in COBRA via SignalR real-time. |

--- a/src/backend/CobraAPI/Core/Models/UserContext.cs
+++ b/src/backend/CobraAPI/Core/Models/UserContext.cs
@@ -47,9 +47,22 @@ public class UserContext
     public List<string> Positions { get; set; } = new();
 
     /// <summary>
+    /// IDs of the positions the user is assigned to.
+    /// Resolved from position names during authentication.
+    /// Used for filtering position-based channels.
+    /// </summary>
+    public List<Guid> PositionIds { get; set; } = new();
+
+    /// <summary>
     /// Indicates if user has admin privileges (for template management)
     /// </summary>
     public bool IsAdmin { get; set; } = false;
+
+    /// <summary>
+    /// The organization the user belongs to.
+    /// Positions and other org-scoped data are filtered by this.
+    /// </summary>
+    public Guid OrganizationId { get; set; }
 
     /// <summary>
     /// Current event ID user is working in (optional)

--- a/src/backend/CobraAPI/GlobalUsings.cs
+++ b/src/backend/CobraAPI/GlobalUsings.cs
@@ -52,6 +52,9 @@ global using CobraAPI.Core.Services;
 global using CobraAPI.Shared.Events.Models.Entities;
 global using CobraAPI.Shared.Events.Models.DTOs;
 global using CobraAPI.Shared.Events.Services;
+global using CobraAPI.Shared.Positions.Models.Entities;
+global using CobraAPI.Shared.Positions.Models.DTOs;
+global using CobraAPI.Shared.Positions.Services;
 
 // Admin module
 global using CobraAPI.Admin.Models.Entities;

--- a/src/backend/CobraAPI/Migrations/20251203210731_AddPositionNameToChannels.Designer.cs
+++ b/src/backend/CobraAPI/Migrations/20251203210731_AddPositionNameToChannels.Designer.cs
@@ -4,16 +4,19 @@ using CobraAPI.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace ChecklistAPI.Migrations
+namespace CobraAPI.Migrations
 {
     [DbContext(typeof(CobraDbContext))]
-    partial class CobraDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251203210731_AddPositionNameToChannels")]
+    partial class AddPositionNameToChannels
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -276,81 +279,6 @@ namespace ChecklistAPI.Migrations
                     b.ToTable("OperationalPeriods");
                 });
 
-            modelBuilder.Entity("CobraAPI.Shared.Positions.Models.Entities.Position", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<string>("Color")
-                        .HasMaxLength(20)
-                        .HasColumnType("nvarchar(20)");
-
-                    b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
-
-                    b.Property<int>("DisplayOrder")
-                        .HasColumnType("int");
-
-                    b.Property<string>("IconName")
-                        .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
-
-                    b.Property<bool>("IsActive")
-                        .HasColumnType("bit");
-
-                    b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("ModifiedBy")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<Guid>("OrganizationId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<Guid>("SourceLanguageId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("OrganizationId");
-
-                    b.HasIndex("OrganizationId", "DisplayOrder");
-
-                    b.HasIndex("OrganizationId", "IsActive");
-
-                    b.ToTable("Positions");
-                });
-
-            modelBuilder.Entity("CobraAPI.Shared.Positions.Models.Entities.PositionTranslation", b =>
-                {
-                    b.Property<Guid>("PositionId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<Guid>("LanguageId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<string>("Description")
-                        .HasMaxLength(500)
-                        .HasColumnType("nvarchar(500)");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
-
-                    b.HasKey("PositionId", "LanguageId");
-
-                    b.HasIndex("LanguageId");
-
-                    b.ToTable("PositionTranslations");
-                });
-
             modelBuilder.Entity("CobraAPI.Tools.Chat.Models.Entities.ChatMessage", b =>
                 {
                     b.Property<Guid>("Id")
@@ -482,14 +410,13 @@ namespace ChecklistAPI.Migrations
                         .HasMaxLength(255)
                         .HasColumnType("nvarchar(255)");
 
-                    b.Property<Guid?>("PositionId")
-                        .HasColumnType("uniqueidentifier");
+                    b.Property<string>("PositionName")
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("ExternalChannelMappingId");
-
-                    b.HasIndex("PositionId");
 
                     b.HasIndex("EventId", "ChannelType");
 
@@ -497,8 +424,8 @@ namespace ChecklistAPI.Migrations
 
                     b.HasIndex("EventId", "IsDefaultEventThread");
 
-                    b.HasIndex("EventId", "PositionId")
-                        .HasFilter("[PositionId] IS NOT NULL");
+                    b.HasIndex("EventId", "ChannelType", "PositionName")
+                        .HasFilter("[ChannelType] = 3");
 
                     b.ToTable("ChatThreads");
                 });
@@ -963,17 +890,6 @@ namespace ChecklistAPI.Migrations
                     b.Navigation("Event");
                 });
 
-            modelBuilder.Entity("CobraAPI.Shared.Positions.Models.Entities.PositionTranslation", b =>
-                {
-                    b.HasOne("CobraAPI.Shared.Positions.Models.Entities.Position", "Position")
-                        .WithMany("Translations")
-                        .HasForeignKey("PositionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Position");
-                });
-
             modelBuilder.Entity("CobraAPI.Tools.Chat.Models.Entities.ChatMessage", b =>
                 {
                     b.HasOne("CobraAPI.Tools.Chat.Models.Entities.ChatThread", "ChatThread")
@@ -1005,16 +921,9 @@ namespace ChecklistAPI.Migrations
                         .HasForeignKey("ExternalChannelMappingId")
                         .OnDelete(DeleteBehavior.NoAction);
 
-                    b.HasOne("CobraAPI.Shared.Positions.Models.Entities.Position", "Position")
-                        .WithMany()
-                        .HasForeignKey("PositionId")
-                        .OnDelete(DeleteBehavior.SetNull);
-
                     b.Navigation("Event");
 
                     b.Navigation("ExternalChannelMapping");
-
-                    b.Navigation("Position");
                 });
 
             modelBuilder.Entity("CobraAPI.Tools.Chat.Models.Entities.ExternalChannelMapping", b =>
@@ -1079,11 +988,6 @@ namespace ChecklistAPI.Migrations
             modelBuilder.Entity("CobraAPI.Shared.Events.Models.Entities.OperationalPeriod", b =>
                 {
                     b.Navigation("Checklists");
-                });
-
-            modelBuilder.Entity("CobraAPI.Shared.Positions.Models.Entities.Position", b =>
-                {
-                    b.Navigation("Translations");
                 });
 
             modelBuilder.Entity("CobraAPI.Tools.Chat.Models.Entities.ChatThread", b =>

--- a/src/backend/CobraAPI/Migrations/20251203210731_AddPositionNameToChannels.cs
+++ b/src/backend/CobraAPI/Migrations/20251203210731_AddPositionNameToChannels.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CobraAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPositionNameToChannels : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PositionName",
+                table: "ChatThreads",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChatThreads_EventId_ChannelType_PositionName",
+                table: "ChatThreads",
+                columns: new[] { "EventId", "ChannelType", "PositionName" },
+                filter: "[ChannelType] = 3");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ChatThreads_EventId_ChannelType_PositionName",
+                table: "ChatThreads");
+
+            migrationBuilder.DropColumn(
+                name: "PositionName",
+                table: "ChatThreads");
+        }
+    }
+}

--- a/src/backend/CobraAPI/Migrations/20251203213206_AddPositionEntities.Designer.cs
+++ b/src/backend/CobraAPI/Migrations/20251203213206_AddPositionEntities.Designer.cs
@@ -4,16 +4,19 @@ using CobraAPI.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace ChecklistAPI.Migrations
+namespace CobraAPI.Migrations
 {
     [DbContext(typeof(CobraDbContext))]
-    partial class CobraDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251203213206_AddPositionEntities")]
+    partial class AddPositionEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/CobraAPI/Migrations/20251203213206_AddPositionEntities.cs
+++ b/src/backend/CobraAPI/Migrations/20251203213206_AddPositionEntities.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CobraAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPositionEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ChatThreads_EventId_ChannelType_PositionName",
+                table: "ChatThreads");
+
+            migrationBuilder.DropColumn(
+                name: "PositionName",
+                table: "ChatThreads");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "PositionId",
+                table: "ChatThreads",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "Positions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    OrganizationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    SourceLanguageId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    IsActive = table.Column<bool>(type: "bit", nullable: false),
+                    IconName = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    Color = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: true),
+                    DisplayOrder = table.Column<int>(type: "int", nullable: false),
+                    CreatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ModifiedBy = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Positions", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PositionTranslations",
+                columns: table => new
+                {
+                    PositionId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    LanguageId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PositionTranslations", x => new { x.PositionId, x.LanguageId });
+                    table.ForeignKey(
+                        name: "FK_PositionTranslations_Positions_PositionId",
+                        column: x => x.PositionId,
+                        principalTable: "Positions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChatThreads_EventId_PositionId",
+                table: "ChatThreads",
+                columns: new[] { "EventId", "PositionId" },
+                filter: "[PositionId] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChatThreads_PositionId",
+                table: "ChatThreads",
+                column: "PositionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Positions_OrganizationId",
+                table: "Positions",
+                column: "OrganizationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Positions_OrganizationId_DisplayOrder",
+                table: "Positions",
+                columns: new[] { "OrganizationId", "DisplayOrder" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Positions_OrganizationId_IsActive",
+                table: "Positions",
+                columns: new[] { "OrganizationId", "IsActive" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PositionTranslations_LanguageId",
+                table: "PositionTranslations",
+                column: "LanguageId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ChatThreads_Positions_PositionId",
+                table: "ChatThreads",
+                column: "PositionId",
+                principalTable: "Positions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ChatThreads_Positions_PositionId",
+                table: "ChatThreads");
+
+            migrationBuilder.DropTable(
+                name: "PositionTranslations");
+
+            migrationBuilder.DropTable(
+                name: "Positions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ChatThreads_EventId_PositionId",
+                table: "ChatThreads");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ChatThreads_PositionId",
+                table: "ChatThreads");
+
+            migrationBuilder.DropColumn(
+                name: "PositionId",
+                table: "ChatThreads");
+
+            migrationBuilder.AddColumn<string>(
+                name: "PositionName",
+                table: "ChatThreads",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChatThreads_EventId_ChannelType_PositionName",
+                table: "ChatThreads",
+                columns: new[] { "EventId", "ChannelType", "PositionName" },
+                filter: "[ChannelType] = 3");
+        }
+    }
+}

--- a/src/backend/CobraAPI/Shared/Positions/Controllers/PositionsController.cs
+++ b/src/backend/CobraAPI/Shared/Positions/Controllers/PositionsController.cs
@@ -1,0 +1,140 @@
+using Microsoft.AspNetCore.Mvc;
+using CobraAPI.Shared.Positions.Models.DTOs;
+using CobraAPI.Shared.Positions.Services;
+
+namespace CobraAPI.Shared.Positions.Controllers;
+
+/// <summary>
+/// API controller for position management.
+/// Positions represent roles within an organization (e.g., ICS positions).
+/// </summary>
+[ApiController]
+[Route("api/positions")]
+public class PositionsController : ControllerBase
+{
+    private readonly IPositionService _positionService;
+    private readonly ILogger<PositionsController> _logger;
+
+    public PositionsController(
+        IPositionService positionService,
+        ILogger<PositionsController> logger)
+    {
+        _positionService = positionService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Gets all positions for the current organization.
+    /// </summary>
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<ActionResult<List<ViewPositionDto>>> GetPositions()
+    {
+        var positions = await _positionService.GetPositionsAsync();
+        return Ok(positions);
+    }
+
+    /// <summary>
+    /// Gets a specific position by ID.
+    /// </summary>
+    [HttpGet("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<ViewPositionDto>> GetPosition(Guid id)
+    {
+        var position = await _positionService.GetPositionAsync(id);
+        if (position == null)
+        {
+            return NotFound("Position not found");
+        }
+        return Ok(position);
+    }
+
+    /// <summary>
+    /// Creates a new position.
+    /// </summary>
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<ViewPositionDto>> CreatePosition([FromBody] PositionDto request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Name))
+        {
+            return BadRequest("Position name is required");
+        }
+
+        var id = await _positionService.CreatePositionAsync(request);
+        var position = await _positionService.GetPositionAsync(id);
+
+        return CreatedAtAction(nameof(GetPosition), new { id }, position);
+    }
+
+    /// <summary>
+    /// Updates an existing position.
+    /// </summary>
+    [HttpPut("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<ViewPositionDto>> UpdatePosition(Guid id, [FromBody] PositionDto request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Name))
+        {
+            return BadRequest("Position name is required");
+        }
+
+        try
+        {
+            await _positionService.UpdatePositionAsync(id, request);
+            var position = await _positionService.GetPositionAsync(id);
+            return Ok(position);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound("Position not found");
+        }
+    }
+
+    /// <summary>
+    /// Deletes a position (soft delete).
+    /// </summary>
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> DeletePosition(Guid id)
+    {
+        try
+        {
+            await _positionService.DeletePositionAsync(id);
+            return NoContent();
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound("Position not found");
+        }
+    }
+
+    /// <summary>
+    /// Seeds default ICS positions for an organization.
+    /// This is typically called during organization setup.
+    /// </summary>
+    [HttpPost("seed-defaults")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<ActionResult<List<ViewPositionDto>>> SeedDefaultPositions()
+    {
+        var userContext = HttpContext.Items["UserContext"] as UserContext;
+        if (userContext == null)
+        {
+            return Unauthorized();
+        }
+
+        await _positionService.SeedDefaultPositionsAsync(userContext.OrganizationId, userContext.Email);
+        var positions = await _positionService.GetPositionsAsync();
+
+        _logger.LogInformation(
+            "Seeded default positions for organization {OrganizationId}",
+            userContext.OrganizationId);
+
+        return Ok(positions);
+    }
+}

--- a/src/backend/CobraAPI/Shared/Positions/Models/DTOs/PositionDtos.cs
+++ b/src/backend/CobraAPI/Shared/Positions/Models/DTOs/PositionDtos.cs
@@ -1,0 +1,63 @@
+namespace CobraAPI.Shared.Positions.Models.DTOs;
+
+/// <summary>
+/// DTO for creating or updating a position.
+/// </summary>
+public class PositionDto
+{
+    /// <summary>
+    /// The name of the position.
+    /// </summary>
+    public required string Name { get; set; }
+
+    /// <summary>
+    /// Optional description.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Optional FontAwesome icon name.
+    /// </summary>
+    public string? IconName { get; set; }
+
+    /// <summary>
+    /// Optional hex color code.
+    /// </summary>
+    public string? Color { get; set; }
+}
+
+/// <summary>
+/// DTO for viewing a position (read-only).
+/// </summary>
+public class ViewPositionDto
+{
+    /// <summary>
+    /// The position ID.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// The translated name in the user's language.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The translated description in the user's language.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// FontAwesome icon name for display.
+    /// </summary>
+    public string? IconName { get; set; }
+
+    /// <summary>
+    /// Hex color code for display.
+    /// </summary>
+    public string? Color { get; set; }
+
+    /// <summary>
+    /// Display order for sorting.
+    /// </summary>
+    public int DisplayOrder { get; set; }
+}

--- a/src/backend/CobraAPI/Shared/Positions/Models/Entities/Position.cs
+++ b/src/backend/CobraAPI/Shared/Positions/Models/Entities/Position.cs
@@ -1,0 +1,52 @@
+namespace CobraAPI.Shared.Positions.Models.Entities;
+
+/// <summary>
+/// Represents a position (role) within an organization.
+/// Positions are organization-specific and translatable.
+/// Examples: "Incident Commander", "Operations Section Chief", "Safety Officer"
+/// </summary>
+public class Position
+{
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// The organization this position belongs to.
+    /// </summary>
+    public Guid OrganizationId { get; set; }
+
+    /// <summary>
+    /// The source language for the position name (for translation fallback).
+    /// </summary>
+    public Guid SourceLanguageId { get; set; }
+
+    /// <summary>
+    /// Whether this position is active (soft delete support).
+    /// </summary>
+    public bool IsActive { get; set; } = true;
+
+    /// <summary>
+    /// Optional icon name for display (FontAwesome icon name).
+    /// </summary>
+    public string? IconName { get; set; }
+
+    /// <summary>
+    /// Optional color for display (hex color code).
+    /// </summary>
+    public string? Color { get; set; }
+
+    /// <summary>
+    /// Display order for sorting positions.
+    /// </summary>
+    public int DisplayOrder { get; set; }
+
+    /// <summary>
+    /// Translations for this position (name, description in different languages).
+    /// </summary>
+    public ICollection<PositionTranslation> Translations { get; set; } = new List<PositionTranslation>();
+
+    // Audit fields
+    public string CreatedBy { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public string? ModifiedBy { get; set; }
+    public DateTime? ModifiedAt { get; set; }
+}

--- a/src/backend/CobraAPI/Shared/Positions/Models/Entities/PositionTranslation.cs
+++ b/src/backend/CobraAPI/Shared/Positions/Models/Entities/PositionTranslation.cs
@@ -1,0 +1,33 @@
+namespace CobraAPI.Shared.Positions.Models.Entities;
+
+/// <summary>
+/// Stores translated name and description for a Position.
+/// Each position can have translations in multiple languages.
+/// </summary>
+public class PositionTranslation
+{
+    /// <summary>
+    /// The position this translation belongs to.
+    /// </summary>
+    public Guid PositionId { get; set; }
+
+    /// <summary>
+    /// Navigation property to the parent position.
+    /// </summary>
+    public Position Position { get; set; } = null!;
+
+    /// <summary>
+    /// The language this translation is for.
+    /// </summary>
+    public Guid LanguageId { get; set; }
+
+    /// <summary>
+    /// The translated name of the position.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional translated description.
+    /// </summary>
+    public string? Description { get; set; }
+}

--- a/src/backend/CobraAPI/Shared/Positions/Services/IPositionService.cs
+++ b/src/backend/CobraAPI/Shared/Positions/Services/IPositionService.cs
@@ -1,0 +1,48 @@
+using CobraAPI.Shared.Positions.Models.DTOs;
+
+namespace CobraAPI.Shared.Positions.Services;
+
+/// <summary>
+/// Service interface for position management.
+/// Positions represent roles within an organization (e.g., ICS positions).
+/// </summary>
+public interface IPositionService
+{
+    /// <summary>
+    /// Gets all active positions for the current organization.
+    /// Returns positions in the user's preferred language with fallback to source language.
+    /// </summary>
+    Task<List<ViewPositionDto>> GetPositionsAsync();
+
+    /// <summary>
+    /// Gets a specific position by ID.
+    /// </summary>
+    Task<ViewPositionDto?> GetPositionAsync(Guid id);
+
+    /// <summary>
+    /// Gets multiple positions by their IDs.
+    /// </summary>
+    Task<List<ViewPositionDto>> GetPositionsAsync(List<Guid> ids);
+
+    /// <summary>
+    /// Creates a new position.
+    /// </summary>
+    /// <returns>The ID of the created position.</returns>
+    Task<Guid> CreatePositionAsync(PositionDto position);
+
+    /// <summary>
+    /// Updates an existing position.
+    /// </summary>
+    Task UpdatePositionAsync(Guid id, PositionDto position);
+
+    /// <summary>
+    /// Soft deletes a position.
+    /// </summary>
+    Task DeletePositionAsync(Guid id);
+
+    /// <summary>
+    /// Seeds the default ICS positions for an organization.
+    /// Called during organization setup.
+    /// </summary>
+    Task SeedDefaultPositionsAsync(Guid organizationId, string createdBy);
+}

--- a/src/backend/CobraAPI/Shared/Positions/Services/PositionService.cs
+++ b/src/backend/CobraAPI/Shared/Positions/Services/PositionService.cs
@@ -1,0 +1,256 @@
+using Microsoft.EntityFrameworkCore;
+using CobraAPI.Core.Data;
+using CobraAPI.Core.Models;
+using CobraAPI.Shared.Positions.Models.DTOs;
+using CobraAPI.Shared.Positions.Models.Entities;
+
+namespace CobraAPI.Shared.Positions.Services;
+
+/// <summary>
+/// Service for position management.
+/// </summary>
+public class PositionService : IPositionService
+{
+    private readonly CobraDbContext _dbContext;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<PositionService> _logger;
+
+    // Default ICS positions with icons and colors
+    private static readonly List<(string Name, string Description, string Icon, string Color, int Order)> DefaultIcsPositions = new()
+    {
+        ("Incident Commander", "Command staff coordination", "star", "#0020C2", 1),
+        ("Operations Section Chief", "Operations section coordination", "cogs", "#E42217", 2),
+        ("Planning Section Chief", "Planning section coordination", "clipboard-list", "#4CAF50", 3),
+        ("Logistics Section Chief", "Logistics section coordination", "truck", "#FF9800", 4),
+        ("Finance/Admin Section Chief", "Finance and administration coordination", "dollar-sign", "#9C27B0", 5),
+        ("Safety Officer", "Safety officer coordination", "shield-halved", "#F44336", 6),
+        ("Public Information Officer", "Public information coordination", "bullhorn", "#2196F3", 7),
+        ("Liaison Officer", "Liaison officer coordination", "handshake", "#00BCD4", 8),
+    };
+
+    // POC: Use a fixed "default" language ID for simplicity
+    private static readonly Guid DefaultLanguageId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+    public PositionService(
+        CobraDbContext dbContext,
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<PositionService> logger)
+    {
+        _dbContext = dbContext;
+        _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
+    }
+
+    private UserContext GetCurrentUser()
+    {
+        return _httpContextAccessor.HttpContext?.Items["UserContext"] as UserContext
+            ?? throw new InvalidOperationException("User context not found");
+    }
+
+    /// <inheritdoc />
+    public async Task<List<ViewPositionDto>> GetPositionsAsync()
+    {
+        var user = GetCurrentUser();
+
+        // Get positions for the current organization
+        // POC: For simplicity, we're using a single language
+        var positions = await _dbContext.Positions
+            .Include(p => p.Translations)
+            .Where(p => p.OrganizationId == user.OrganizationId && p.IsActive)
+            .OrderBy(p => p.DisplayOrder)
+            .ThenBy(p => p.Translations.First().Name)
+            .ToListAsync();
+
+        return positions.Select(MapToViewDto).ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<ViewPositionDto?> GetPositionAsync(Guid id)
+    {
+        var position = await _dbContext.Positions
+            .Include(p => p.Translations)
+            .FirstOrDefaultAsync(p => p.Id == id && p.IsActive);
+
+        return position != null ? MapToViewDto(position) : null;
+    }
+
+    /// <inheritdoc />
+    public async Task<List<ViewPositionDto>> GetPositionsAsync(List<Guid> ids)
+    {
+        var positions = await _dbContext.Positions
+            .Include(p => p.Translations)
+            .Where(p => ids.Contains(p.Id) && p.IsActive)
+            .OrderBy(p => p.DisplayOrder)
+            .ToListAsync();
+
+        return positions.Select(MapToViewDto).ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<Guid> CreatePositionAsync(PositionDto positionDto)
+    {
+        var user = GetCurrentUser();
+        var positionId = Guid.NewGuid();
+
+        // Get the next display order
+        var maxOrder = await _dbContext.Positions
+            .Where(p => p.OrganizationId == user.OrganizationId && p.IsActive)
+            .MaxAsync(p => (int?)p.DisplayOrder) ?? 0;
+
+        var position = new Position
+        {
+            Id = positionId,
+            OrganizationId = user.OrganizationId,
+            SourceLanguageId = DefaultLanguageId,
+            IsActive = true,
+            IconName = positionDto.IconName,
+            Color = positionDto.Color,
+            DisplayOrder = maxOrder + 1,
+            CreatedBy = user.Email,
+            CreatedAt = DateTime.UtcNow,
+        };
+
+        var translation = new PositionTranslation
+        {
+            PositionId = positionId,
+            LanguageId = DefaultLanguageId,
+            Name = positionDto.Name,
+            Description = positionDto.Description,
+        };
+
+        _dbContext.Positions.Add(position);
+        _dbContext.PositionTranslations.Add(translation);
+        await _dbContext.SaveChangesAsync();
+
+        _logger.LogInformation("Created position {Name} with ID {Id}", positionDto.Name, positionId);
+
+        return positionId;
+    }
+
+    /// <inheritdoc />
+    public async Task UpdatePositionAsync(Guid id, PositionDto positionDto)
+    {
+        var user = GetCurrentUser();
+
+        var position = await _dbContext.Positions
+            .Include(p => p.Translations)
+            .FirstOrDefaultAsync(p => p.Id == id && p.IsActive);
+
+        if (position == null)
+        {
+            throw new KeyNotFoundException($"Position {id} not found");
+        }
+
+        // Update position properties
+        position.IconName = positionDto.IconName;
+        position.Color = positionDto.Color;
+        position.ModifiedBy = user.Email;
+        position.ModifiedAt = DateTime.UtcNow;
+
+        // Update or create translation
+        var translation = position.Translations.FirstOrDefault(t => t.LanguageId == DefaultLanguageId);
+        if (translation != null)
+        {
+            translation.Name = positionDto.Name;
+            translation.Description = positionDto.Description;
+        }
+        else
+        {
+            _dbContext.PositionTranslations.Add(new PositionTranslation
+            {
+                PositionId = id,
+                LanguageId = DefaultLanguageId,
+                Name = positionDto.Name,
+                Description = positionDto.Description,
+            });
+        }
+
+        await _dbContext.SaveChangesAsync();
+
+        _logger.LogInformation("Updated position {Id} to {Name}", id, positionDto.Name);
+    }
+
+    /// <inheritdoc />
+    public async Task DeletePositionAsync(Guid id)
+    {
+        var position = await _dbContext.Positions.FindAsync(id);
+        if (position == null)
+        {
+            throw new KeyNotFoundException($"Position {id} not found");
+        }
+
+        // Soft delete
+        position.IsActive = false;
+        position.ModifiedBy = GetCurrentUser().Email;
+        position.ModifiedAt = DateTime.UtcNow;
+
+        await _dbContext.SaveChangesAsync();
+
+        _logger.LogInformation("Soft deleted position {Id}", id);
+    }
+
+    /// <inheritdoc />
+    public async Task SeedDefaultPositionsAsync(Guid organizationId, string createdBy)
+    {
+        // Check if positions already exist for this organization
+        var existingCount = await _dbContext.Positions
+            .CountAsync(p => p.OrganizationId == organizationId && p.IsActive);
+
+        if (existingCount > 0)
+        {
+            _logger.LogInformation("Organization {OrganizationId} already has {Count} positions, skipping seed",
+                organizationId, existingCount);
+            return;
+        }
+
+        foreach (var (name, description, icon, color, order) in DefaultIcsPositions)
+        {
+            var positionId = Guid.NewGuid();
+
+            var position = new Position
+            {
+                Id = positionId,
+                OrganizationId = organizationId,
+                SourceLanguageId = DefaultLanguageId,
+                IsActive = true,
+                IconName = icon,
+                Color = color,
+                DisplayOrder = order,
+                CreatedBy = createdBy,
+                CreatedAt = DateTime.UtcNow,
+            };
+
+            var translation = new PositionTranslation
+            {
+                PositionId = positionId,
+                LanguageId = DefaultLanguageId,
+                Name = name,
+                Description = description,
+            };
+
+            _dbContext.Positions.Add(position);
+            _dbContext.PositionTranslations.Add(translation);
+        }
+
+        await _dbContext.SaveChangesAsync();
+
+        _logger.LogInformation("Seeded {Count} default ICS positions for organization {OrganizationId}",
+            DefaultIcsPositions.Count, organizationId);
+    }
+
+    private static ViewPositionDto MapToViewDto(Position position)
+    {
+        // Get the first translation (POC uses single language)
+        var translation = position.Translations.FirstOrDefault();
+
+        return new ViewPositionDto
+        {
+            Id = position.Id,
+            Name = translation?.Name ?? "Unknown",
+            Description = translation?.Description,
+            IconName = position.IconName,
+            Color = position.Color,
+            DisplayOrder = position.DisplayOrder,
+        };
+    }
+}

--- a/src/backend/CobraAPI/Tools/Chat/Models/DTOs/ChatDTOs.cs
+++ b/src/backend/CobraAPI/Tools/Chat/Models/DTOs/ChatDTOs.cs
@@ -36,6 +36,17 @@ public class ChatThreadDto
     public int DisplayOrder { get; set; }
     public string? IconName { get; set; }
     public string? Color { get; set; }
+
+    /// <summary>
+    /// For Position channels, the ID of the associated Position.
+    /// </summary>
+    public Guid? PositionId { get; set; }
+
+    /// <summary>
+    /// For Position channels, the position details.
+    /// </summary>
+    public PositionChannelDto? Position { get; set; }
+
     public int MessageCount { get; set; }
     public DateTime CreatedAt { get; set; }
 
@@ -71,6 +82,13 @@ public class CreateChannelRequest
     public ChannelType ChannelType { get; set; } = ChannelType.Custom;
     public string? IconName { get; set; }
     public string? Color { get; set; }
+
+    /// <summary>
+    /// Optional position ID for Position channels.
+    /// When set, only users assigned to this position can see the channel.
+    /// If ChannelType is Position, this should be set.
+    /// </summary>
+    public Guid? PositionId { get; set; }
 }
 
 /// <summary>
@@ -116,4 +134,16 @@ public class UpdateChannelRequest
 public class SendMessageRequest
 {
     public string Message { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Embedded position info for Position channels.
+/// </summary>
+public class PositionChannelDto
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string? IconName { get; set; }
+    public string? Color { get; set; }
 }

--- a/src/backend/CobraAPI/Tools/Chat/Models/Entities/ChatThread.cs
+++ b/src/backend/CobraAPI/Tools/Chat/Models/Entities/ChatThread.cs
@@ -56,6 +56,17 @@ public class ChatThread
     public string? Color { get; set; }
 
     /// <summary>
+    /// For Position channels, the ID of the associated Position entity.
+    /// Used to filter visibility to users assigned to this position.
+    /// </summary>
+    public Guid? PositionId { get; set; }
+
+    /// <summary>
+    /// Navigation property to the Position (if this is a Position channel).
+    /// </summary>
+    public Position? Position { get; set; }
+
+    /// <summary>
     /// For External channels, the ID of the linked ExternalChannelMapping.
     /// Null for internal channels.
     /// </summary>

--- a/src/backend/CobraAPI/Tools/Chat/Services/IChannelService.cs
+++ b/src/backend/CobraAPI/Tools/Chat/Services/IChannelService.cs
@@ -78,4 +78,27 @@ public interface IChannelService
     /// <param name="olderThanDays">Archive messages older than this many days.</param>
     /// <returns>Number of messages archived.</returns>
     Task<int> ArchiveMessagesOlderThanAsync(Guid channelId, int olderThanDays);
+
+    /// <summary>
+    /// Creates position-based channels for an event.
+    /// Each ICS position gets its own channel for position-specific coordination.
+    /// </summary>
+    /// <param name="eventId">The event ID.</param>
+    /// <param name="createdBy">The user creating the channels.</param>
+    /// <returns>List of created channel DTOs.</returns>
+    Task<List<ChatThreadDto>> CreatePositionChannelsAsync(Guid eventId, string createdBy);
+
+    /// <summary>
+    /// Gets channels visible to the user based on their assigned position IDs and role.
+    /// Position channels are only visible to users assigned to that position,
+    /// unless the user has Manage role (which can see all channels),
+    /// or the user created the channel (creator can always see their channel).
+    /// Other channel types (Internal, Announcements, External, Custom) are visible to all.
+    /// </summary>
+    /// <param name="eventId">The event ID.</param>
+    /// <param name="userPositionIds">The IDs of positions the user is assigned to.</param>
+    /// <param name="userEmail">The user's email to check channel ownership.</param>
+    /// <param name="canManage">Whether the user has Manage role (can see all position channels).</param>
+    /// <returns>List of channels visible to the user.</returns>
+    Task<List<ChatThreadDto>> GetUserVisibleChannelsAsync(Guid eventId, List<Guid> userPositionIds, string userEmail, bool canManage = false);
 }

--- a/src/frontend/src/core/components/ProfileMenu.tsx
+++ b/src/frontend/src/core/components/ProfileMenu.tsx
@@ -29,11 +29,13 @@ import {
   DialogContent,
   DialogActions,
   TextField,
+  CircularProgress,
 } from '@mui/material';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronDown, faPalette, faUserPen, faShieldHalved } from '@fortawesome/free-solid-svg-icons';
 import { useSearchParams } from 'react-router-dom';
-import { ICS_POSITIONS, PermissionRole } from '../../types';
+import { PermissionRole } from '../../types';
+import { usePositions } from '../../shared/positions';
 import { useSysAdmin } from '../../admin/contexts/SysAdminContext';
 import { cobraTheme } from '../../theme/cobraTheme';
 import {
@@ -134,6 +136,7 @@ export const ProfileMenu: React.FC<ProfileMenuProps> = ({ onProfileChange }) => 
   const storedAccount = getStoredAccount();
   const [searchParams, setSearchParams] = useSearchParams();
   const { isSysAdmin } = useSysAdmin();
+  const { positionNames, loading: positionsLoading } = usePositions();
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [selectedPositions, setSelectedPositions] = useState<string[]>(storedProfile.positions);
@@ -398,27 +401,33 @@ export const ProfileMenu: React.FC<ProfileMenuProps> = ({ onProfileChange }) => 
             Select one or more ICS positions
           </Typography>
           <Box sx={{ maxHeight: 200, overflowY: 'auto' }}>
-            {ICS_POSITIONS.map((position) => (
-              <FormControlLabel
-                key={position}
-                control={
-                  <Checkbox
-                    checked={selectedPositions.includes(position)}
-                    onChange={() => handlePositionToggle(position)}
-                    size="small"
-                  />
-                }
-                label={
-                  <Typography variant="body2">
-                    {position}
-                    {position === primaryPosition && (
-                      <Chip label="Primary" size="small" sx={{ ml: 1, height: 18, fontSize: '0.7rem' }} />
-                    )}
-                  </Typography>
-                }
-                sx={{ display: 'flex', width: '100%', mx: 0 }}
-              />
-            ))}
+            {positionsLoading ? (
+              <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+                <CircularProgress size={24} />
+              </Box>
+            ) : (
+              positionNames.map((position) => (
+                <FormControlLabel
+                  key={position}
+                  control={
+                    <Checkbox
+                      checked={selectedPositions.includes(position)}
+                      onChange={() => handlePositionToggle(position)}
+                      size="small"
+                    />
+                  }
+                  label={
+                    <Typography variant="body2">
+                      {position}
+                      {position === primaryPosition && (
+                        <Chip label="Primary" size="small" sx={{ ml: 1, height: 18, fontSize: '0.7rem' }} />
+                      )}
+                    </Typography>
+                  }
+                  sx={{ display: 'flex', width: '100%', mx: 0 }}
+                />
+              ))
+            )}
           </Box>
         </Box>
 
@@ -438,7 +447,7 @@ export const ProfileMenu: React.FC<ProfileMenuProps> = ({ onProfileChange }) => 
                 value={PermissionRole.READONLY}
                 control={<Radio size="small" />}
                 label={
-                  <Box>
+                  <Box component="span" sx={{ display: 'block' }}>
                     <Typography variant="body2" sx={{ fontWeight: 'bold' }}>
                       Readonly
                     </Typography>
@@ -452,7 +461,7 @@ export const ProfileMenu: React.FC<ProfileMenuProps> = ({ onProfileChange }) => 
                 value={PermissionRole.CONTRIBUTOR}
                 control={<Radio size="small" />}
                 label={
-                  <Box>
+                  <Box component="span" sx={{ display: 'block' }}>
                     <Typography variant="body2" sx={{ fontWeight: 'bold' }}>
                       Contributor
                     </Typography>
@@ -466,7 +475,7 @@ export const ProfileMenu: React.FC<ProfileMenuProps> = ({ onProfileChange }) => 
                 value={PermissionRole.MANAGE}
                 control={<Radio size="small" />}
                 label={
-                  <Box>
+                  <Box component="span" sx={{ display: 'block' }}>
                     <Typography variant="body2" sx={{ fontWeight: 'bold' }}>
                       Manage
                     </Typography>
@@ -499,7 +508,7 @@ export const ProfileMenu: React.FC<ProfileMenuProps> = ({ onProfileChange }) => 
                   value={variant.id}
                   control={<Radio size="small" />}
                   label={
-                    <Box>
+                    <Box component="span" sx={{ display: 'block' }}>
                       <Typography variant="body2" sx={{ fontWeight: 'bold' }}>
                         {variant.name}
                       </Typography>
@@ -533,7 +542,7 @@ export const ProfileMenu: React.FC<ProfileMenuProps> = ({ onProfileChange }) => 
                   value={variant.id}
                   control={<Radio size="small" />}
                   label={
-                    <Box>
+                    <Box component="span" sx={{ display: 'block' }}>
                       <Typography variant="body2" sx={{ fontWeight: 'bold' }}>
                         {variant.name}
                       </Typography>

--- a/src/frontend/src/shared/positions/hooks/usePositions.ts
+++ b/src/frontend/src/shared/positions/hooks/usePositions.ts
@@ -1,0 +1,102 @@
+/**
+ * usePositions Hook
+ * Fetches positions from the API with caching
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { positionService } from '../services/positionService';
+import type { Position } from '../types';
+
+// Cache for positions (shared across all instances of the hook)
+let cachedPositions: Position[] | null = null;
+let cachePromise: Promise<Position[]> | null = null;
+
+export const usePositions = () => {
+  const [positions, setPositions] = useState<Position[]>(cachedPositions || []);
+  const [loading, setLoading] = useState(!cachedPositions);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchPositions = useCallback(async (forceRefresh = false) => {
+    // If cached and not forcing refresh, use cache
+    if (cachedPositions && !forceRefresh) {
+      setPositions(cachedPositions);
+      setLoading(false);
+      return;
+    }
+
+    // If already fetching, wait for that promise
+    if (cachePromise && !forceRefresh) {
+      try {
+        setLoading(true);
+        const data = await cachePromise;
+        setPositions(data);
+        setError(null);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load positions');
+      } finally {
+        setLoading(false);
+      }
+      return;
+    }
+
+    // Start new fetch
+    setLoading(true);
+    setError(null);
+
+    cachePromise = positionService.getPositions();
+
+    try {
+      const data = await cachePromise;
+      cachedPositions = data;
+      setPositions(data);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load positions';
+      setError(message);
+      console.error('Failed to fetch positions:', err);
+    } finally {
+      setLoading(false);
+      cachePromise = null;
+    }
+  }, []);
+
+  // Fetch on mount
+  useEffect(() => {
+    fetchPositions();
+  }, [fetchPositions]);
+
+  // Get position names for backward compatibility
+  const positionNames = positions.map((p) => p.name);
+
+  // Get position by name
+  const getPositionByName = useCallback(
+    (name: string): Position | undefined => {
+      return positions.find((p) => p.name.toLowerCase() === name.toLowerCase());
+    },
+    [positions]
+  );
+
+  // Get position by ID
+  const getPositionById = useCallback(
+    (id: string): Position | undefined => {
+      return positions.find((p) => p.id === id);
+    },
+    [positions]
+  );
+
+  // Clear cache (useful for testing or after admin changes)
+  const clearCache = useCallback(() => {
+    cachedPositions = null;
+    cachePromise = null;
+  }, []);
+
+  return {
+    positions,
+    positionNames,
+    loading,
+    error,
+    refetch: () => fetchPositions(true),
+    getPositionByName,
+    getPositionById,
+    clearCache,
+  };
+};

--- a/src/frontend/src/shared/positions/index.ts
+++ b/src/frontend/src/shared/positions/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Positions Module
+ * Provides position management for the application
+ */
+
+export * from './types';
+export * from './hooks/usePositions';
+export { positionService } from './services/positionService';

--- a/src/frontend/src/shared/positions/services/positionService.ts
+++ b/src/frontend/src/shared/positions/services/positionService.ts
@@ -1,0 +1,33 @@
+/**
+ * Position Service
+ * Provides API calls for position management
+ */
+
+import { apiClient } from '../../../core/services/api';
+import type { Position } from '../types';
+
+export const positionService = {
+  /**
+   * Fetch all positions for the current organization
+   */
+  getPositions: async (): Promise<Position[]> => {
+    const response = await apiClient.get<Position[]>('/api/positions');
+    return response.data;
+  },
+
+  /**
+   * Fetch a specific position by ID
+   */
+  getPosition: async (id: string): Promise<Position> => {
+    const response = await apiClient.get<Position>(`/api/positions/${id}`);
+    return response.data;
+  },
+
+  /**
+   * Seed default ICS positions (admin only)
+   */
+  seedDefaultPositions: async (): Promise<Position[]> => {
+    const response = await apiClient.post<Position[]>('/api/positions/seed-defaults');
+    return response.data;
+  },
+};

--- a/src/frontend/src/shared/positions/types/index.ts
+++ b/src/frontend/src/shared/positions/types/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Position Types
+ * Matches backend ViewPositionDto
+ */
+
+export interface Position {
+  id: string;
+  name: string;
+  description?: string;
+  iconName?: string;
+  color?: string;
+  displayOrder: number;
+}

--- a/src/frontend/src/tools/chat/components/ChatSidebar.tsx
+++ b/src/frontend/src/tools/chat/components/ChatSidebar.tsx
@@ -84,6 +84,22 @@ export const ChatSidebar: React.FC = () => {
     setShowChannelList(true);
   }, [currentEvent?.id]);
 
+  // Reset selected channel when profile changes (position or account change)
+  // This ensures we don't show a channel the user can no longer access
+  useEffect(() => {
+    const handleProfileChange = () => {
+      console.log('[ChatSidebar] Profile changed, resetting selected channel');
+      setSelectedChannel(null);
+      setShowChannelList(true);
+    };
+    window.addEventListener('profileChanged', handleProfileChange);
+    window.addEventListener('accountChanged', handleProfileChange);
+    return () => {
+      window.removeEventListener('profileChanged', handleProfileChange);
+      window.removeEventListener('accountChanged', handleProfileChange);
+    };
+  }, []);
+
   // Load external channels when event changes
   useEffect(() => {
     const loadExternalChannels = async () => {

--- a/src/frontend/src/tools/chat/pages/ChatPage.tsx
+++ b/src/frontend/src/tools/chat/pages/ChatPage.tsx
@@ -151,7 +151,7 @@ export const ChatPage: React.FC = () => {
       setChannelsLoading(true);
       setChannelsError(null);
       const [channelsData, externalData] = await Promise.all([
-        chatService.getChannels(currentEvent.id),
+        chatService.getUserVisibleChannels(currentEvent.id),
         chatService.getExternalChannels(currentEvent.id),
       ]);
       setChannels(channelsData);
@@ -178,6 +178,20 @@ export const ChatPage: React.FC = () => {
 
   useEffect(() => {
     loadChannels();
+  }, [loadChannels]);
+
+  // Refresh channels when profile changes (position or account change)
+  useEffect(() => {
+    const handleProfileChange = () => {
+      console.log('[ChatPage] Profile changed, refreshing channels');
+      loadChannels();
+    };
+    window.addEventListener('profileChanged', handleProfileChange);
+    window.addEventListener('accountChanged', handleProfileChange);
+    return () => {
+      window.removeEventListener('profileChanged', handleProfileChange);
+      window.removeEventListener('accountChanged', handleProfileChange);
+    };
   }, [loadChannels]);
 
   // Reset selection when event changes

--- a/src/frontend/src/tools/chat/services/chatService.ts
+++ b/src/frontend/src/tools/chat/services/chatService.ts
@@ -171,6 +171,30 @@ export const chatService = {
     return response.data.archivedCount;
   },
 
+  /**
+   * Creates position-based channels for an event.
+   * Creates one channel for each ICS position (Command, Operations, Planning, etc.).
+   * @returns List of created position channels.
+   */
+  createPositionChannels: async (eventId: string): Promise<ChatThreadDto[]> => {
+    const response = await apiClient.post<ChatThreadDto[]>(
+      `/api/events/${eventId}/chat/channels/position`
+    );
+    return response.data;
+  },
+
+  /**
+   * Gets channels visible to the current user based on their positions.
+   * Position channels are only visible to users assigned to that position.
+   * Other channel types are visible to all users.
+   */
+  getUserVisibleChannels: async (eventId: string): Promise<ChatThreadDto[]> => {
+    const response = await apiClient.get<ChatThreadDto[]>(
+      `/api/events/${eventId}/chat/channels/visible`
+    );
+    return response.data;
+  },
+
   // ===== Legacy Thread API =====
 
   /**

--- a/src/frontend/src/tools/chat/types/chat.ts
+++ b/src/frontend/src/tools/chat/types/chat.ts
@@ -56,6 +56,8 @@ export interface ChatThreadDto {
   displayOrder: number;
   iconName?: string;
   color?: string;
+  /** For Position channels, the full ICS position name for filtering */
+  positionName?: string;
   messageCount: number;
   createdAt: string;
   /** Whether the channel is active (false = archived) */
@@ -225,6 +227,11 @@ export interface CreateChannelRequest {
   channelType: ChannelType;
   iconName?: string;
   color?: string;
+  /**
+   * Optional position ID for Position channels.
+   * When set, only users assigned to this position can see the channel.
+   */
+  positionId?: string;
 }
 
 /**

--- a/src/frontend/src/tools/chat/types/positionChannels.ts
+++ b/src/frontend/src/tools/chat/types/positionChannels.ts
@@ -1,0 +1,143 @@
+/**
+ * Position Channel Configuration
+ *
+ * ICS (Incident Command System) positions and their display configuration.
+ * Used for position-based chat channels with specific icons and colors.
+ */
+
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import {
+  faStar,
+  faCogs,
+  faClipboardList,
+  faTruck,
+  faDollarSign,
+  faShieldHalved,
+  faBullhorn,
+  faHandshake,
+  faUserGroup,
+} from '@fortawesome/free-solid-svg-icons';
+
+/**
+ * Configuration for a position channel.
+ */
+export interface PositionChannelConfig {
+  /** Full ICS position name */
+  name: string;
+  /** Short name for display (used as channel name) */
+  shortName: string;
+  /** FontAwesome icon */
+  icon: IconDefinition;
+  /** Icon name string (for backend/storage) */
+  iconName: string;
+  /** Hex color */
+  color: string;
+  /** Channel description */
+  description: string;
+}
+
+/**
+ * Position channel configurations indexed by position name.
+ */
+export const PositionChannelConfigs: Record<string, PositionChannelConfig> = {
+  'Incident Commander': {
+    name: 'Incident Commander',
+    shortName: 'Command',
+    icon: faStar,
+    iconName: 'star',
+    color: '#0020C2', // Cobalt Blue - Command authority
+    description: 'Command staff coordination',
+  },
+  'Operations Section Chief': {
+    name: 'Operations Section Chief',
+    shortName: 'Operations',
+    icon: faCogs,
+    iconName: 'cogs',
+    color: '#E42217', // Lava Red - Operations (action)
+    description: 'Operations section coordination',
+  },
+  'Planning Section Chief': {
+    name: 'Planning Section Chief',
+    shortName: 'Planning',
+    icon: faClipboardList,
+    iconName: 'clipboard-list',
+    color: '#4CAF50', // Green - Planning (growth/progress)
+    description: 'Planning section coordination',
+  },
+  'Logistics Section Chief': {
+    name: 'Logistics Section Chief',
+    shortName: 'Logistics',
+    icon: faTruck,
+    iconName: 'truck',
+    color: '#FF9800', // Orange - Logistics (movement/supply)
+    description: 'Logistics section coordination',
+  },
+  'Finance/Admin Section Chief': {
+    name: 'Finance/Admin Section Chief',
+    shortName: 'Finance/Admin',
+    icon: faDollarSign,
+    iconName: 'dollar-sign',
+    color: '#9C27B0', // Purple - Finance (royalty/value)
+    description: 'Finance and administration coordination',
+  },
+  'Safety Officer': {
+    name: 'Safety Officer',
+    shortName: 'Safety',
+    icon: faShieldHalved,
+    iconName: 'shield-halved',
+    color: '#F44336', // Red - Safety (warning/alert)
+    description: 'Safety officer coordination',
+  },
+  'Public Information Officer': {
+    name: 'Public Information Officer',
+    shortName: 'PIO',
+    icon: faBullhorn,
+    iconName: 'bullhorn',
+    color: '#2196F3', // Blue - PIO (communication)
+    description: 'Public information coordination',
+  },
+  'Liaison Officer': {
+    name: 'Liaison Officer',
+    shortName: 'Liaison',
+    icon: faHandshake,
+    iconName: 'handshake',
+    color: '#00BCD4', // Cyan - Liaison (connection)
+    description: 'Liaison officer coordination',
+  },
+};
+
+/**
+ * Get position channel config by position name.
+ * Falls back to a default config if position not found.
+ */
+export const getPositionChannelConfig = (positionName: string): PositionChannelConfig => {
+  return (
+    PositionChannelConfigs[positionName] ?? {
+      name: positionName,
+      shortName: positionName,
+      icon: faUserGroup,
+      iconName: 'user-group',
+      color: '#607D8B', // Blue Grey - Default
+      description: `${positionName} coordination`,
+    }
+  );
+};
+
+/**
+ * Get FontAwesome icon for a position channel by icon name string.
+ */
+export const getPositionIcon = (iconName: string): IconDefinition => {
+  const iconMap: Record<string, IconDefinition> = {
+    star: faStar,
+    cogs: faCogs,
+    'clipboard-list': faClipboardList,
+    truck: faTruck,
+    'dollar-sign': faDollarSign,
+    'shield-halved': faShieldHalved,
+    bullhorn: faBullhorn,
+    handshake: faHandshake,
+    'user-group': faUserGroup,
+  };
+
+  return iconMap[iconName] ?? faUserGroup;
+};


### PR DESCRIPTION
- Add Position entity with i18n translations support
- Create PositionService and PositionsController for CRUD operations
- Update ChatThread to use PositionId foreign key instead of PositionName
- Implement channel visibility filtering based on user positions:
  - Position channels only visible to users assigned to that position
  - Managers can see all position channels
  - Channel creators can always see their own channels
- Add usePositions hook for frontend position data fetching
- Update CreateChannelDialog with position selector
- Add profile/account change listeners to refresh channel lists
- Seed 8 ICS positions on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)